### PR TITLE
Remove npm from production Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,8 @@ ENV NEXT_TELEMETRY_DISABLED 1
 
 # Create non-root user
 RUN addgroup --system --gid 1001 nodejs && \
-    adduser --system --uid 1001 nextjs
+    adduser --system --uid 1001 nextjs && \
+    rm -rf /usr/local/lib/node_modules/npm
 
 # Copy essential files
 COPY --from=builder /app/public ./public


### PR DESCRIPTION
## Summary
- Remove npm package from production Docker image to reduce attack surface and improve security
- This follows security best practices by excluding unnecessary build tools from the runtime environment

## Test plan
- [ ] Build Docker image successfully
- [ ] Verify application runs correctly without npm in production
- [ ] Check image size reduction

🤖 Generated with [Claude Code](https://claude.com/claude-code)